### PR TITLE
Making Source0 "spectool friendly"

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -8,7 +8,7 @@ Packager:      Kazuhisa Hara <kazuhisya@gmail.com>
 Group:         Development/Libraries
 License:       MIT License
 URL:           http://nodejs.org
-Source0:       %{_base}-v%{version}.tar.gz
+Source0:       %{url}/dist/v%{version}/%{_base}-v%{version}.tar.gz
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-tmp
 Obsoletes:     npm
 Provides:      npm


### PR DESCRIPTION
There's a tool called `spectool` that comes together with [rpmdevtools](http://fedoraproject.org/wiki/Rpmdevtools), which can expand and download sources (and patches) defined in specfile. Sample usage:

```
spectool -g -R nodejs.spec
```

But to make it work `Source0` has to contain full path/url to source file. It seems that there's now fixed layout of `nodejs.org/dist/`, so why not to use it?
