### PR TITLE
Always include the CentOS 5 patch in SRPM to fix mock builds

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -25,8 +25,8 @@ BuildRequires: zlib-devel
 %if "%{_dist_ver}" == ".el5"
 # require EPEL
 BuildRequires: python26
-Patch0: node-js.centos5.configure.patch
 %endif
+Patch0: node-js.centos5.configure.patch
 
 %description
 Node.js is a server-side JavaScript environment that uses an asynchronous event-driven model.


### PR DESCRIPTION
When using mock for builds on CentOS 6 to build packages for CentOS 5, the SRPM is built on CentOS 6. The patch file doesn't get included, which makes the CentOS 5 build fail. This change causes the patch file to be included always. This is harmless for CentOS 6 builds, because the patch won't be applied there.
