### PR TITLE
Dividing core and npm 

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -3,7 +3,7 @@
 
 Name:          %{_base}js
 Version:       0.10.18
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       Node.js is a server-side JavaScript environment that uses an asynchronous event-driven model.
 Packager:      Kazuhisa Hara <kazuhisya@gmail.com>
 Group:         Development/Libraries
@@ -22,6 +22,7 @@ BuildRequires: make
 BuildRequires: openssl-devel
 BuildRequires: libstdc++-devel
 BuildRequires: zlib-devel
+BuildRequires: gzip
 %if "%{_dist_ver}" == ".el5"
 # require EPEL
 BuildRequires: python26
@@ -82,10 +83,13 @@ fi
     --shared-zlib \
     --shared-zlib-includes=%{_includedir}
 make binary %{?_smp_mflags}
-cd $RPM_SOURCE_DIR
+
+pushd $RPM_SOURCE_DIR
 mv $RPM_BUILD_DIR/%{_base}-v%{version}/%{_base}-v%{version}-linux-%{_node_arch}.tar.gz .
 rm  -rf %{_base}-v%{version}
 tar zxvf %{_base}-v%{version}-linux-%{_node_arch}.tar.gz
+popd
+
 
 %install
 rm -rf $RPM_BUILD_ROOT
@@ -98,6 +102,21 @@ for file in ChangeLog LICENSE README.md ; do
 done
 mkdir -p $RPM_BUILD_ROOT/usr/share/%{_base}js
 mv $RPM_SOURCE_DIR/%{_base}-v%{version}-linux-%{_node_arch}.tar.gz $RPM_BUILD_ROOT/usr/share/%{_base}js/
+
+# prefix all manpages with "npm-"
+pushd $RPM_BUILD_ROOT/usr/lib/node_modules/npm/man/
+for dir in *; do
+    mkdir -p $RPM_BUILD_ROOT/usr/share/man/$dir
+    pushd $dir
+    for page in *; do
+        if [[ $page != npm* ]]; then
+        mv $page npm-$page
+    fi
+    done
+    popd
+    cp $dir/* $RPM_BUILD_ROOT/usr/share/man/$dir
+done
+popd
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -121,7 +140,15 @@ rm -rf $RPM_BUILD_ROOT
 %{_prefix}/lib/node_modules/npm
 %{_bindir}/npm
 
+%doc
+/usr/share/man/man1
+/usr/share/man/man3
+/usr/share/man/man5
+/usr/share/man/man7
+
 %changelog
+* Fri Sep 13 2013 Kazuhisa Hara <kazuhisya@gmail.com>
+- Apply the man file of npm package
 * Thu Sep 12 2013 Kazuhisa Hara <kazuhisya@gmail.com>
 - Dividing core and npm #25
 * Sun Sep  8 2013 Kazuhisa Hara <kazuhisya@gmail.com>


### PR DESCRIPTION
Node.js and npm was distributed separately before. However, came to be bundled from node.js 0.6.3 before and after.
Since then, I changed it to generate, including the npm to rpm of node.js.
but began to think better to divide it normally is or not good.
Fix: #25 
