### PR TITLE
Update python dependency to python27.

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -27,7 +27,7 @@ BuildRequires: gzip
 
 %if "%{_dist_ver}" == ".el5"
 # require EPEL
-BuildRequires: python26
+BuildRequires: python27
 %endif
 Patch0: node-js.centos5.configure.patch
 
@@ -76,7 +76,7 @@ rm -rf $RPM_SOURCE_DIR/%{_base}-v%{version}
 
 %build
 %if "%{_dist_ver}" == ".el5"
-export PYTHON=python26
+export PYTHON=python27
 %endif
 %define _node_arch %{nil}
 %ifarch x86_64


### PR DESCRIPTION
Apparently node configuration is dependent on it.
Reference: https://github.com/joyent/node/issues/9217

When building on centos with python26 I used to get the following error: 
```
[01:10:34][Step 1/1] File "../../tools/js2c.py", line 409
[01:10:34][Step 1/1] except Error as e:
[01:10:34][Step 1/1] ^
[01:10:34][Step 1/1] SyntaxError: invalid syntax
[01:10:34][Step 1/1] make[2]: *** [/root/rpmbuild/BUILD/node-v0.12.0/out/Release/obj/gen/libraries.cc] Error 1
````
By updating to python27 the issue is gone.