### PR TITLE
Update BuildRequires

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -24,6 +24,7 @@ BuildRequires: openssl-devel
 BuildRequires: libstdc++-devel
 BuildRequires: zlib-devel
 BuildRequires: gzip
+BuildRequires: python
 
 %if "%{_dist_ver}" == ".el5"
 # require EPEL


### PR DESCRIPTION
Added BuildRequires: python to spec file.

This is to allow the SRPM to be compiled by mock for the COPR repo.

Otherwise an error occurs and the build fails:

/usr/bin/env: python: No such file or directory