### PR TITLE
fixed source0 download errors due to HTTPS enforcement

### DIFF
--- a/nodejs.spec
+++ b/nodejs.spec
@@ -11,7 +11,7 @@ Summary:       Node.js is a server-side JavaScript environment that uses an asyn
 Packager:      Kazuhisa Hara <kazuhisya@gmail.com>
 Group:         Development/Libraries
 License:       MIT License
-URL:           http://nodejs.org
+URL:           https://nodejs.org
 Source0:       %{url}/dist/v%{version}/%{_base}-v%{version}.tar.gz
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-tmp
 Prefix:        /usr


### PR DESCRIPTION
nodejs.org now enforces HTTPS and the build process was unable to follow the HTTP -> HTTPS transition.